### PR TITLE
Plot experimental and simulation data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ moc*
 Makefile
 .qmake.stash
 qrc_images1.cpp
+qrc_tests.cpp
 qrc_aiscshapedatabase.cpp
 ui_mainwindow.h
 

--- a/BMA.pro
+++ b/BMA.pro
@@ -62,4 +62,5 @@ FORMS += \
         mainwindow.ui
 
 RESOURCES += \
-    aiscshapedatabase.qrc
+    aiscshapedatabase.qrc \
+    tests.qrc

--- a/hysteresiswidget.cpp
+++ b/hysteresiswidget.cpp
@@ -134,16 +134,20 @@ void hysteresisWidget::plotModel()
     thePlot->clearPlottables();
     //thePlot->clearGraphs();
     //thePlot->clearItems();
-
+    thePlot->legend->setVisible(true);
+    
     // create curves
     curve1 = new QCPCurve(thePlot->xAxis, thePlot->yAxis);
     curve2 = new QCPCurve(thePlot->xAxis, thePlot->yAxis);
 
+    curve1->setName(tr("Experimental"));
+    curve2->setName(tr("Simulation"));
+
     // create pen
     QPen pen;
     pen.setWidthF(3);
-    // pen.setColor(QColor(Qt::gray));
-    // curve1->setPen(pen);
+    pen.setColor(QColor(Qt::gray));
+    curve1->setPen(pen);
     pen.setColor(QColor(Qt::blue));
     curve2->setPen(pen);
 
@@ -168,6 +172,7 @@ void hysteresisWidget::plotResponse(int t)
     plotModel();
 
     // set data
+    curve1->setData(xi->mid(0,t),yi->mid(0,t));    
     curve2->setData(xj->mid(0,t),yj->mid(0,t));
 
     // update plot

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -193,7 +193,11 @@ MainWindow::MainWindow(QWidget *parent) :
     // initialize data
     initialize();
     reset();
+
+    setCurrentFile(":/ExampleFiles/TCBF3_W8X28.json");
+    loadFile(":/ExampleFiles/TCBF3_W8X28.json");
 }
+
 //---------------------------------------------------------------
 MainWindow::~MainWindow()
 {

--- a/tests.qrc
+++ b/tests.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>ExampleFiles/TCBF3_W8X28.json</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
This pull request adds the following:
* Experimental and simulation data are plotted together at same time interval on hysteresis plot. Legend on plot shows which is which.
* Automatically loads example experiment on startup