### PR TITLE
Fixes `Segmentation Fault` when running analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ ui_mainwindow.h
 *.exe
 *.out
 *.app
-BMA
+BFM
 
 # QT
 uqFEM.pro.user

--- a/BFM.pro
+++ b/BFM.pro
@@ -9,7 +9,7 @@ QT       += sql
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets printsupport
 
-TARGET = BMA
+TARGET = BFM
 TEMPLATE = app
 
 # The following define makes your compiler emit warnings if you use

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3149,7 +3149,7 @@ void MainWindow::setExp(Experiment *exp)
 void MainWindow::createHeaderBox()
 {
     HeaderWidget *header = new HeaderWidget();
-    header->setHeadingText(tr("Brace Modeling Application"));
+    header->setHeadingText(tr("Braced Frame Modeling"));
     largeLayout->addWidget(header);
 }
 
@@ -3162,7 +3162,7 @@ void MainWindow::createFooterBox()
 
 void setLimits(QDoubleSpinBox *widget, int min, int max, int decimal = 0, double step = 1)
 {
-    widget->setMaximum(min);
+    widget->setMinimum(min);
     widget->setMaximum(max);
     widget->setDecimals(decimal);
     widget->setSingleStep(step);
@@ -3170,7 +3170,7 @@ void setLimits(QDoubleSpinBox *widget, int min, int max, int decimal = 0, double
 
 void setLimits(QSpinBox *widget, int min, int max, double step = 1)
 {
-    widget->setMaximum(min);
+    widget->setMinimum(min);
     widget->setMaximum(max);
     widget->setSingleStep(step);
 }


### PR DESCRIPTION
The pull request includes the following:
* Fixes bug that was causing program to crash when pressing *Run* button. Bug was due to error in `setLimits` function where minimum was never set, so values in widgets could be set inappropriately causing analysis to crash
* Changes header to say *Braced Frame Modeling* instead of *Brace Modeling Application*.