### PR TITLE
Reload default experiment when pressing reset; player only plays analysis once

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -324,6 +324,10 @@ void MainWindow::reset()
     // initialize experiment
     Experiment *exp = new Experiment();
     setExp(exp);
+
+    // Load default experiment
+    setCurrentFile(":/ExampleFiles/TCBF3_W8X28.json");
+    loadFile(":/ExampleFiles/TCBF3_W8X28.json");
 }
 
 // Set the current file name

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2086,13 +2086,13 @@ void MainWindow::play_clicked()
 
     // play loop
     do {
-        //slider->setSliderPosition(currentStep);
         slider->setValue(stepCurr);
         QCoreApplication::processEvents();
         stepCurr++;
 
-        if (stepCurr++ == numSteps)
-            stepCurr = 0;
+        if (stepCurr++ == numSteps) {
+	  pause = true;	  
+	}
 
     } while (pause == false);
 }


### PR DESCRIPTION
This pull request contains the following:
* Reload default experiment when pressing *reset* button